### PR TITLE
fix: disable always-on for elastic premium plans

### DIFF
--- a/modules/linux-function/locals.tf
+++ b/modules/linux-function/locals.tf
@@ -1,8 +1,9 @@
 locals {
-  is_consumption = data.azurerm_service_plan.plan.sku_name == "Y1"
+  is_consumption     = contains(["Y1"], data.azurerm_service_plan.plan.sku_name)
+  is_elastic_premium = contains(["EP1", "EP2", "EP3"], data.azurerm_service_plan.plan.sku_name)
 
   default_site_config = {
-    always_on                              = !local.is_consumption
+    always_on                              = !local.is_consumption && !local.is_elastic_premium
     application_insights_connection_string = var.application_insights_enabled ? local.app_insights.connection_string : null
     application_insights_key               = var.application_insights_enabled ? local.app_insights.instrumentation_key : null
   }

--- a/modules/linux-function/r-function.tf
+++ b/modules/linux-function/r-function.tf
@@ -1,7 +1,7 @@
 # Data Service Plan
 data "azurerm_service_plan" "plan" {
   name                = element(split("/", var.service_plan_id), 8)
-  resource_group_name = var.resource_group_name
+  resource_group_name = element(split("/", var.service_plan_id), 4)
 }
 
 # Function App

--- a/modules/windows-function/locals.tf
+++ b/modules/windows-function/locals.tf
@@ -1,8 +1,9 @@
 locals {
-  is_consumption = data.azurerm_service_plan.plan.sku_name == "Y1"
+  is_consumption     = contains(["Y1"], data.azurerm_service_plan.plan.sku_name)
+  is_elastic_premium = contains(["EP1", "EP2", "EP3"], data.azurerm_service_plan.plan.sku_name)
 
   default_site_config = {
-    always_on                              = !local.is_consumption
+    always_on                              = !local.is_consumption && !local.is_elastic_premium
     application_insights_connection_string = var.application_insights_enabled ? local.app_insights.connection_string : null
     application_insights_key               = var.application_insights_enabled ? local.app_insights.instrumentation_key : null
   }

--- a/modules/windows-function/r-function.tf
+++ b/modules/windows-function/r-function.tf
@@ -1,7 +1,7 @@
 # Data Service Plan
 data "azurerm_service_plan" "plan" {
   name                = element(split("/", var.service_plan_id), 8)
-  resource_group_name = var.resource_group_name
+  resource_group_name = element(split("/", var.service_plan_id), 4)
 }
 
 # Function App


### PR DESCRIPTION
This PR disables `always_on` feature on **Elastic Premium** SKUs, in addition to consumption plans, as it is not supported;

Basically you will get a vague error about "server returned error" if we enable `always_on` for those SKUs. However, when you enable debug log, it is visible that such a setting is not accepted by Azure RM APIs.

This issue is also mentioned here: https://medium.com/@pihikj/azure-do-not-enable-alwayson-on-elastic-premium-plan-bb2eca010fb4 

Additionally, the current module assumes the service plan to exist in the same resource group as the function app, which is not always the case, specially when the service plan is created outside of this module. So, it is better to extract the resource group name from the full `service_plan_id`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request
- disable always_on feature when using Elastic Premium function plans
- extract the resource group name of the service plan from the id
-

@claranet/fr-azure-reviewers
